### PR TITLE
removes root logger configuration

### DIFF
--- a/pwnedpasswords/pwnedpasswords.py
+++ b/pwnedpasswords/pwnedpasswords.py
@@ -36,7 +36,6 @@ from . import exceptions
 
 looks_like_sha1_re = re.compile(r"^[a-fA-F0-9]{40}")
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 def check(password, plain_text=False, anonymous=True):

--- a/test_pwnedpasswords.py
+++ b/test_pwnedpasswords.py
@@ -7,19 +7,19 @@ from . import pwnedpasswords
 class TestPwnedPasswords(unittest.TestCase):
     def setUp(self):
         self.value = "123123"
-        self.num_matches = 2048411
+        self.num_matches = 2194818
         self.password = pwnedpasswords.Password(self.value)
 
     def test_check(self):
-        assert(self.password.check() == self.num_matches)
+        self.assertEqual(self.password.check(), self.num_matches)
 
     def test_search(self):
-        assert(self.password.search() == self.num_matches)
+        self.assertEqual(self.password.search(), self.num_matches)
 
     def test_range(self):
         sha = "601F1889667EFAEBB33B8C12572835DA3F027F78"
         result = self.password.range().get(sha[5:])
-        assert(result == self.num_matches)
+        self.assertEqual(result, self.num_matches)
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TestPwnedPasswords)

--- a/test_pwnedpasswords.py
+++ b/test_pwnedpasswords.py
@@ -13,9 +13,6 @@ class TestPwnedPasswords(unittest.TestCase):
     def test_check(self):
         self.assertEqual(self.password.check(), self.num_matches)
 
-    def test_search(self):
-        self.assertEqual(self.password.search(), self.num_matches)
-
     def test_range(self):
         sha = "601F1889667EFAEBB33B8C12572835DA3F027F78"
         result = self.password.range().get(sha[5:])


### PR DESCRIPTION
Removes root logger configuration to avoid unexpected logging behavior.  For example, before importing `pwnedpasswords` the application was set to log at `WARN` and above.  After importing, it is now set to `DEBUG`.

```python
IPython 7.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import logging

In [2]: logging.getLogger().level
Out[2]: 30

In [3]: import pwnedpasswords

In [4]: logging.getLogger().level
Out[4]: 10
```